### PR TITLE
Add CPF Compatibility

### DIFF
--- a/nfe/utils/response.py
+++ b/nfe/utils/response.py
@@ -30,7 +30,7 @@ class Response:
                     "SerieRPS": i.find('.//SerieRPS', namespaces={}).text,
                     "NumeroRPS": i.find('.//NumeroRPS', namespaces={}).text,
                     "DataEmissaoNFe": i.find('.//DataEmissaoNFe', namespaces={}).text,
-                    "CPFCNPJTomador": i.find('.//CPFCNPJTomador/CNPJ', namespaces={}).text,
+                    "CPFCNPJTomador": i.find('.//CPFCNPJTomador', namespaces={})[0].text,
                     "CodigoVerificacao": i.find('.//CodigoVerificacao', namespaces={}).text,
                     "NumeroNFe": i.find('.//NumeroNFe', namespaces={}).text
                 })

--- a/nfe/utils/rps.py
+++ b/nfe/utils/rps.py
@@ -14,8 +14,12 @@ class Rps:
                      NumeroEndereco, ComplementoEndereco, Bairro, Cidade, UF, CEP, EmailTomador, Discriminacao,
                      privateKeyContent, certificateContent):
 
+        CPFCNPJTomadorTag = "CPF"
+        if len(CPFCNPJTomador) > 11:
+            CPFCNPJTomadorTag = "CNPJ"
+
         rpsToSign = "{InscricaoPrestador}{SerieRPS}{NumeroRPS}{DataEmissao}{TributacaoRPS}{StatusRPS}" \
-                    "{ISSRetido}{ValorServicos}{ValorDeducoes}{CodigoServico}2{RazaoSocialTomador}".format(
+                    "{ISSRetido}{ValorServicos}{ValorDeducoes}{CodigoServico}{CPFCNPJ}{RazaoSocialTomador}".format(
             InscricaoPrestador=InscricaoPrestador.zfill(8),
             SerieRPS=SerieRPS.ljust(5).upper(),
             NumeroRPS=NumeroRPS.zfill(12),
@@ -26,6 +30,7 @@ class Rps:
             ValorServicos=str(ValorServicos).zfill(15),
             ValorDeducoes=str(ValorDeducoes).zfill(15),
             CodigoServico=CodigoServico.zfill(5),
+            CPFCNPJ=("1" if CPFCNPJTomadorTag == "CPF" else "2"),
             RazaoSocialTomador=CPFCNPJTomador.zfill(14),
         )
 
@@ -52,6 +57,7 @@ class Rps:
             "AliquotaServicos": Currency.formatted(AliquotaServicos),
             "ISSRetido": ISSRetido,
             "CPFCNPJTomador": CPFCNPJTomador,
+            "CPFCNPJTomadorTag": CPFCNPJTomadorTag,
             "RazaoSocialTomador": RazaoSocialTomador,
             "Logradouro": Logradouro,
             "NumeroEndereco": NumeroEndereco,

--- a/nfe/utils/schemas.py
+++ b/nfe/utils/schemas.py
@@ -34,7 +34,7 @@ schemaCreateRps = """
                             <AliquotaServicos>{AliquotaServicos}</AliquotaServicos>
                             <ISSRetido>{ISSRetido}</ISSRetido>
                             <CPFCNPJTomador>
-                                <CNPJ>{CPFCNPJTomador}</CNPJ>
+                                <{CPFCNPJTomadorTag}>{CPFCNPJTomador}</{CPFCNPJTomadorTag}>
                             </CPFCNPJTomador>
                             <RazaoSocialTomador>{RazaoSocialTomador}</RazaoSocialTomador>
                             <EnderecoTomador>


### PR DESCRIPTION
Agora sim, somente os ajustes corretos!

- Testo o tamanho do campo `CPFCNPJTomador` para determinar se é CPF ou CNPJ
- Ajusto a assinatura de acordo com o que foi passado (`1` ou `2`)
- Incluí um parâmetro `CPFCNPJTomadorTag` para formar a tag corretamente
- Ao buscar a resposta, trago o primeiro elemento dentro de `CPFCNPJTomador` (e não mais `CNPJ` fixo)

Não se preocupem em relação ao pacote que eu subi na minha conta. Eu só precisava emitir as notas deste mês e deu certo graças ao trabalho anterior de vocês! Caso vocês aprovem o PR, eu vou excluir e substituir por este.

Obrigado e parabéns pelo ótimo trabalho! (Não só neste repositório mas em toda a Starkbank, eu sou fã!)

Abraços,
Bruno.